### PR TITLE
Small additions to SerialUSB

### DIFF
--- a/STM32/cores/arduino/stm32/SerialUSB.cpp
+++ b/STM32/cores/arduino/stm32/SerialUSB.cpp
@@ -55,13 +55,15 @@ void SerialUSBClass::init(void){
   pinMode(PA12, OUTPUT);
   digitalWrite(PA12, LOW);
   //HAL_Delay(1000);
-  for(i=0;i<512;i++){};
-  digitalWrite(PA12, HIGH);
+  for(i=0;i<1512;i++){};
+  pinMode(PA12, INPUT);
+  //digitalWrite(PA12, HIGH);
   //HAL_Delay(1000);
   for(i=0;i<512;i++){};
 #endif
   MX_USB_DEVICE_Init();
 }
+
 
 
 void SerialUSBClass::begin(uint32_t baud_count){
@@ -179,7 +181,9 @@ SerialUSBClass::operator bool()
 		return false;
 
 	bool result = false;
-
+	if(hUsbDeviceFS.dev_state == USBD_STATE_CONFIGURED){
+		result = true;
+	}
 /* 	if (_usbLineInfo.lineState > 0)
 	{
 		result = true;


### PR DESCRIPTION
Resolves enumeration problem in F4 and !Serial never returning true.
When the USB port connects to a host goes thru several states, and can
start sending data once the state is USBD_STATE_CONFIGURED